### PR TITLE
Use no_pre_path when making image path relative

### DIFF
--- a/inc/functions/functions-portal-landing.php
+++ b/inc/functions/functions-portal-landing.php
@@ -329,7 +329,7 @@ function portal_display_card( $i, $url, $title, $excerpt, $image, $date, $label 
 		$type = portal_card_label( $url, $label );
 		$date_html = portal_card_date( $date, $type );
 		$target = ( $type == 'Event' ) ? ' target="_blank"' : '';
-		$image = make_path_relative( $image );
+		$image = make_path_relative_no_pre_path( $image );
 
 		if ( $i == 0 ) {
 			$col_class = 'col-card-12';


### PR DESCRIPTION
Calls to images held in wp-content/uploads need to have the child-site pre-path removed - there is a function for this already so the change is to call this function rather than the one that includes the child site.

This is a fix to #125 