### PR TITLE
Removed function and call to retrieve mega menu

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -101,9 +101,6 @@ add_theme_support( 'post-thumbnails' );
 // Call shortcode inside wordpress by using [newsletter-back-button]
 add_shortcode('newsletter-back-button', 'get_query_string_newsletter_previous_url');
 
-// Set path to mega menu HTML
-set_path_to_mega_menu(served_from_local_machine($_SERVER['SERVER_ADDR'], $_SERVER['REMOTE_ADDR']));
-
 if ( $_SERVER['REQUEST_URI'] == '/xmlrpc.php' || $_SERVER['REQUEST_URI'] == '/xmlrpc.php?rsd' ) {
 	wp_redirect( site_url() );
 	exit;

--- a/header.php
+++ b/header.php
@@ -79,16 +79,7 @@
     <nav id="nav" role="navigation" class="navigation">
         <div class="mega-menu clearfix">
             <?php
-		global $cloud;
-		if (!$cloud) {
-			if (file_exists(PATH_TO_MEGA_MENU_HTML)) {
-				include PATH_TO_MEGA_MENU_HTML;
-			} else {
-                get_template_part( 'partials/mega-menu' );
-			}
-		} else {
             get_template_part( 'partials/mega-menu' );
-        }
 		?>
         </div>
     </nav>

--- a/inc/functions-non-cloud.php
+++ b/inc/functions-non-cloud.php
@@ -71,18 +71,6 @@ function served_from_local_machine($server_ip, $remote_ip)
 	return ($server_ip === $remote_ip);
 }
 
-/**
- * @param $development_machine - boolean obtained from calling served_from_local_machine()
- */
-function set_path_to_mega_menu($development_machine)
-{
-	if ($development_machine === true) {
-		define("PATH_TO_MEGA_MENU_HTML", 'output.html');
-	} else {
-		define("PATH_TO_MEGA_MENU_HTML", 'D:/webapps/phpapps/mega-menu-feed-processor/output.html');
-	}
-}
-
 function check_for_specific_url_path($url_path = '') {
 	$protocol = isset($_SERVER["HTTPS"]) ? 'https' : 'http';
 	$url = $protocol.'://nationalarchives.gov.uk';

--- a/partials/mega-menu.php
+++ b/partials/mega-menu.php
@@ -16,8 +16,6 @@
             <li><a data-gtm="mega-menu" href="https://www.nationalarchives.gov.uk/education/sessions-and-resources/?time-period=medieval,early-modern,empire-and-industry,victorians,early-20th-century,interwar,second-world-war,postwar">Time periods</a></li>
             <li><a data-gtm="mega-menu" href="https://www.nationalarchives.gov.uk/education/sessions-and-resources/?resource-type=lesson">Lessons</a></li>
             <li><a data-gtm="mega-menu" href="https://www.nationalarchives.gov.uk/education/sessions-and-resources/?resource-type=workshop">Workshops</a></li>
-            <li><a data-gtm="mega-menu" href="https://www.nationalarchives.gov.uk/education/sessions-and-resources/?resource-type=video-conferences">Videoconferences</a></li>
-            <li><a data-gtm="mega-menu" href="https://www.nationalarchives.gov.uk/education/sessions-and-resources/?resource-type=virtual-classroom">Virtual classroom</a></li>
             <li><a data-gtm="mega-menu" href="https://www.nationalarchives.gov.uk/education/teachers/professional-development/">Professional development</a></li>
             <li><a data-gtm="mega-menu" href="https://www.nationalarchives.gov.uk/education/teachers/">For teachers</a></li>
             <li><a data-gtm="mega-menu" href="https://www.nationalarchives.gov.uk/education/students/">For students</a></li>

--- a/tests/TNAGlobalsTest.php
+++ b/tests/TNAGlobalsTest.php
@@ -12,18 +12,6 @@ class TNAGlobalsTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(served_from_local_machine('127.0.0.1', '127.0.0.2', 'When passed non-identical arguments, false is returned'));
     }
 
-    public function test_path_to_mega_menu_local()
-    {
-        set_path_to_mega_menu(true);
-        $this->assertEquals(PATH_TO_MEGA_MENU_HTML, 'output.html');
-    }
-
-    public function test_path_to_mega_menu_remote()
-    {
-        set_path_to_mega_menu(false);
-        $this->assertEquals(PATH_TO_MEGA_MENU_HTML, 'D:/webapps/phpapps/mega-menu-feed-processor/output.html');
-    }
-
     public function test_check_for_specific_url_path_exists()
     {
         $this->assertTrue(function_exists('check_for_specific_url_path'));


### PR DESCRIPTION
A while back in an attempt to make updating the mega menu easier an app was created to manage the mega menu but, rather than reducing the places to updae the mega menu it just increased it ... by two - so I have reverted to using the mega menu that is within the theme rather than loading it from an external file.

This PR removes the functions that set the location of the mega menu file and instead just uses the include within the theme.