### PR TITLE
Feature/library link hack

### DIFF
--- a/inc/functions-cards.php
+++ b/inc/functions-cards.php
@@ -28,8 +28,7 @@ function display_card( $args = '' ) {
 
     if ( $r['url'] ) {
 
-        if ( !url_exists( $r['url'] ) ) {
-
+        if ( !url_exists( $r['url'] && !strpos($r['url'], 'koha-ptfs' ) ) {
             // ext URL return 404
             return card_fallback( '', $r['id'] );
         }

--- a/inc/functions-cards.php
+++ b/inc/functions-cards.php
@@ -28,10 +28,12 @@ function display_card( $args = '' ) {
 
     if ( $r['url'] ) {
 
-        if ( !url_exists( $r['url'] && !strpos($r['url'], 'koha-ptfs' ) ) {
-            // ext URL return 404
-            return card_fallback( '', $r['id'] );
-        }
+	if ( !strpos($r['url'] , 'koha' ) ) {
+            if ( !url_exists( $r['url']) ) {
+                // ext URL return 404
+                return card_fallback( '', $r['id'] );
+            }
+	}
 
         if ( $r['label'] == '' || $r['label'] == 'Auto' ) {
             $label = content_type( $r['url'] );


### PR DESCRIPTION
We have an issue that at the moment the live server isn't able to validate the library URL which means that on the help-with-your-research homepage the fallback card is displayed despite the fact that the link is in fact valid.

This is a little hack to ignore the response and display the card anyway.

We've had a bit of discussion over whether this check should be in place at all - and that maintaining links is editorial not technical work! But while that debate is ongoing...

If you see a better way - please shout!