### PR TITLE
Move qunit tests from PhantomJS to Headless Chromium

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,9 @@
 module.exports = function(grunt) {
+
+  var chromiumFlags = process.env.CI
+    ? ['--no-sandbox']
+    : (process.env.CHROMIUM_FLAGS || '').split(' ');
+
   // Project configuration.
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
@@ -36,16 +41,18 @@ module.exports = function(grunt) {
       small: {
         src: ['js/tests/**/*.html'],
         options: {
-          page: {
-            viewportSize: { width: 300, height: 400 }
+          puppeteer: {
+            args: chromiumFlags,
+            defaultViewport: { width: 300, height: 400 }
           }
         }
       },
       large: {
         src: ['js/tests/**/*.html'],
         options: {
-          page: {
-            viewportSize: { width: 1024, height: 400 }
+          puppeteer: {
+            args: chromiumFlags,
+            defaultViewport: { width: 1024, height: 400 }
           }
         }
       }

--- a/js/tests/Example/example.html
+++ b/js/tests/Example/example.html
@@ -4,12 +4,12 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <title>QUnit Example</title>
-    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.0.1.css">
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.19.0.css">
 </head>
 <body>
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>
-<script src="https://code.jquery.com/qunit/qunit-2.0.1.js"></script>
+<script src="https://code.jquery.com/qunit/qunit-2.19.0.js"></script>
 <script src="tests.js"></script>
 </body>
 </html>

--- a/js/tests/mega-menu/test.html
+++ b/js/tests/mega-menu/test.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <title>QUnit Example</title>
-    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.0.1.css">
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.19.0.css">
     <style>
         #nav {
             display: none;
@@ -140,7 +140,7 @@
     </nav>
 </div>
 
-<script src="https://code.jquery.com/qunit/qunit-2.0.1.js"></script>
+<script src="https://code.jquery.com/qunit/qunit-2.19.0.js"></script>
 <script src="../../lib/jquery-1.11.3.min.js"></script>
 <script src="../../mega-menu.js"></script>
 <script src="tests.js"></script>

--- a/js/tests/mitigating_target_blank/test.html
+++ b/js/tests/mitigating_target_blank/test.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <title>Mitigating Target Blank</title>
-    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.0.1.css">
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.19.0.css">
 </head>
 <body>
 <div id="qunit"></div>
@@ -17,7 +17,7 @@
         <li><a href="#" target="_blank">Link 5</a></li>
     </ul>
 </div>
-<script src="https://code.jquery.com/qunit/qunit-2.0.1.js"></script>
+<script src="https://code.jquery.com/qunit/qunit-2.19.0.js"></script>
 <script src="../../lib/jquery-1.11.3.min.js"></script>
 <script src="../../mitigate-target-blank.js"></script>
 <script src="tests.js"></script>

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "grunt-contrib-cssmin": "^0.13.0",
     "grunt-contrib-jasmine": "^2.0.2",
     "grunt-contrib-jshint": "^2.0.0",
-    "grunt-contrib-nodeunit": "^2.0.0",
-    "grunt-contrib-qunit": "^1.2.0",
+    "grunt-contrib-qunit": "^6.0.0",
     "grunt-contrib-sass": "^0.9.2",
     "grunt-contrib-uglify": "^2.0.0",
     "grunt-contrib-watch": "^1.1.0"


### PR DESCRIPTION
PhantomJS is no longer maintained and I was unable to get the tests to pass in a development environment running the latest Debian Linux.

Update grunt-contrib-qunit to the latest version, which uses Puppeteer to drive the latest Chromium version instead of PhantomJS.

grunt-contrib-qunit 6 requires QUnit 2.2.0 or later, so while at it also update the test files from QUnit 2.0.1 to 2.19.0.

See also:
* <https://github.com/gruntjs/grunt-contrib-qunit>.
* <https://pptr.dev/#?product=Puppeteer&version=v9.0.0&show=api-puppeteerlaunchoptions>